### PR TITLE
Fixed bug that caused last question in quiz to saved wrong

### DIFF
--- a/src/pages/Recommender.tsx
+++ b/src/pages/Recommender.tsx
@@ -42,10 +42,7 @@ class Recommender extends React.Component<RouteComponentProps, IRecommenderState
     }
     
     componentDidMount() : void {
-        if(this.state.answers.length > 0){
-            this.getNextQuestion(this.state.answers)
-        }
-        else{
+        if(this.state.answers.length === 0){
             questionManager.getFirstQuestion().then((qst) => {
                 let newState = {
                     routeTo: this.state.routeTo,


### PR DESCRIPTION
This bug occurred when you went back in the browser history from the results page, causing multiple question twenties to be stored. Making it possible to go back again but the question number staying at 20.

This fix causes the right behavior to happen instead. With only 1 question 20 stored at any time.