### PR TITLE
Fixes the recommender size for desktop

### DIFF
--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -53,19 +53,14 @@ class ResultPage extends React.Component<RouteComponentProps, IRecommenderState>
     }
 
     renderPrimaryRecommendation() : ReactNode {
-        const elems:React.ReactElement[] = [];
         const primary:Education = this.state.list[0];
 
-        elems.push(
-            <div className={'primary-edu-block div-spacing'}>
-                { resultPageCommon.renderEducationInfo(primary) }
-                <hr/>
-                { resultPageCommon.renderEducationTypes(primary.education_types) }
-            </div>
-        )
-
         return (
-            <div> { elems } </div>
+            <div className={'primary-edu-block div-spacing col-lg-7'}>
+                { resultPageCommon.renderEducationInfo(primary)}
+                <hr />
+                { resultPageCommon.renderEducationTypes(primary.education_types)}
+            </div>
         )
     }
 
@@ -76,7 +71,7 @@ class ResultPage extends React.Component<RouteComponentProps, IRecommenderState>
             let edu:Education = edu2;
 
             elems.push(
-                <div className={'edu-block div-spacing'}>
+                <div className={'edu-block div-spacing col-lg-7'}>
                     { resultPageCommon.renderEducationInfo(edu) }
                     <hr/>
                     { resultPageCommon.renderEducationTypes(edu.education_types) }
@@ -84,9 +79,7 @@ class ResultPage extends React.Component<RouteComponentProps, IRecommenderState>
             )
         }
 
-        return (
-            <div> {elems} </div>
-        )
+        return elems;
     }
 
     render() {
@@ -102,7 +95,7 @@ class ResultPage extends React.Component<RouteComponentProps, IRecommenderState>
                 <div className={'row justify-content-center'}>
                     {this.renderTitle('result.rem_title')}
                 </div>
-                <div className={'row justify-content-center'}>
+                <div className={'row justify-content-center align-items-center'}>
                     {this.state.loading ? '' : this.renderRemainingRecommendations()}
                 </div>
             </div>


### PR DESCRIPTION
The only difference should be in the width of the elements on desktop.

[Before (desktop)](https://user-images.githubusercontent.com/5766695/99229706-a6426180-27ee-11eb-85d3-8b9cfdf1416f.png)
[After (desktop)](https://user-images.githubusercontent.com/5766695/99229652-96c31880-27ee-11eb-918a-273706b4c00e.png)

[Before (mobile)](https://user-images.githubusercontent.com/5766695/99229754-b4907d80-27ee-11eb-837b-56ed9ca1ba01.png)
[After (mobile)](https://user-images.githubusercontent.com/5766695/99229797-c4a85d00-27ee-11eb-8286-f2a853a19b79.png)

