### PR TITLE
Route data page

### DIFF
--- a/src/i18n/da.ts
+++ b/src/i18n/da.ts
@@ -4,7 +4,8 @@ const daMessages = {
         index: {
             title: "EduFinder",
             rec_btn: "Uddannelsesforslag",
-            guess_btn: "Start quiz",
+            guess_btn: "Uddannelsesgætter",
+            data_btn: "Start quiz",
             data_collection: "Dataindsamling"
         },
         recommender: {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,7 +4,8 @@ const enMessages = {
         index: {
             title: "EduFinder",
             rec_btn: "Education recommender",
-            guess_btn: "Start quiz",
+            guess_btn: "Guessing game",
+            data_btn: "Start quiz",
             data_collection: "Data collection"
         },
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ const Routes = () => {
         <Route exact path="/">
           <Index />
         </Route>
-        <Route exact path="/data/">
+        <Route exact path="/:data/" >
           <Index />
         </Route>
         <Route exact path="/quiz/">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,8 @@ import DataCollection from './pages/DataCollection';
 import Thanks from './pages/Thanks'
 import NavbarComponent from "./pages/commons/Navbar";
 import './styling/style.scss'
+import Result from "./pages/Result";
+import Guess from "./pages/Guess";
 
 
 const Routes = () => {
@@ -18,8 +20,17 @@ const Routes = () => {
         <Route exact path="/">
           <Index />
         </Route>
+        <Route exact path="/data/">
+          <Index />
+        </Route>
         <Route exact path="/quiz/">
           <Recommender />
+        </Route>
+        <Route exact path="/results/">
+          <Result />
+        </Route>
+        <Route exact path="/guess/">
+          <Guess />
         </Route>
         <Route exact path="/datacollection/">
           <DataCollection />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,11 +12,18 @@ interface IIndexState {
   data_collection: boolean;
 }
 
+interface Params {
+  data?: string;
+}
+
 class Index extends React.Component<RouteComponentProps, IIndexState> {
   constructor(props: any) {
     super(props);
 
-    const data_collection = /\/data\/?/.exec(this.props.location.pathname) != null;
+    let data_collection: boolean = false;
+    const params: Params = this.props.match.params;
+
+    if (params.data) data_collection = true;
 
     this.state = {
       easterBreen: '',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,15 +9,19 @@ import '../styling/breen.css'
 interface IIndexState {
   easterBreen: string;
   logo: string;
+  data_collection: boolean;
 }
 
 class Index extends React.Component<RouteComponentProps, IIndexState> {
   constructor(props: any) {
     super(props);
 
+    const data_collection = /\/data\/?/.exec(this.props.location.pathname) != null;
+
     this.state = {
       easterBreen: '',
       logo: logo,
+      data_collection: data_collection
     }
   }
 
@@ -40,6 +44,25 @@ class Index extends React.Component<RouteComponentProps, IIndexState> {
     return (
       <img alt={'EduFinder'} className={'header-logo img-fluid '} src={this.state.logo}/>
     )
+  }
+
+  renderButtonSegment() {
+    if (this.state.data_collection) {
+      return (
+        <div className={'d-flex justify-content-center mt-4'}>
+          {this.renderButton('index.data_btn', "/datacollection/")}
+        </div>
+      )
+    } else {
+      return [
+        <div className={'d-flex justify-content-center mt-4'}>
+          {this.renderButton('index.rec_btn', "/results/")}
+        </div>,
+        <div className={'d-flex justify-content-center mt-4'}>
+          {this.renderButton('index.guess_btn', "/guess/")}
+        </div>
+      ]
+    }
   }
 
   setEasterBreen = (easterBreen: string) => {
@@ -69,9 +92,7 @@ class Index extends React.Component<RouteComponentProps, IIndexState> {
         <div className={'d-flex justify-content-center'}>
           {this.renderLogo()}
         </div>
-        <div className={'d-flex justify-content-center mt-4'}>
-          {this.renderButton('index.guess_btn', "/datacollection/")}
-        </div>
+          {this.renderButtonSegment()}
         <div className={'breen-container'}></div>
         </div>
       </div>


### PR DESCRIPTION
Addition to the `datacollector-page` branch. This routes the data collection page to `/data/` and retains the regular recommendation/guessing mode on `/`.